### PR TITLE
mpf_t |-> mpf_ptr in PackedFloat

### DIFF
--- a/include/PackedFloat.h
+++ b/include/PackedFloat.h
@@ -54,7 +54,7 @@ class PackedFloat {
     }
 
 #ifndef HLSLIB_SYNTHESIS  // Interoperability with GMP/MPFR, but only on the host side
-    inline PackedFloat(const mpf_t num) {
+    inline PackedFloat(mpf_srcptr num) {
         // Copy the most significant bytes, padding zeros if necessary
         const auto num_limbs = std::min(size_t(std::abs(num->_mp_size)),
                                         (mpf_get_prec(num) + 8 * sizeof(mp_limb_t) - 1) / (8 * sizeof(mp_limb_t)));
@@ -80,12 +80,12 @@ class PackedFloat {
         sign = num->_mpfr_sign < 0;  // 1 if negative, 0 otherwise
     }
 
-    inline PackedFloat &operator=(const mpf_t num) {
+    inline PackedFloat &operator=(mpf_srcptr num) {
         *this = PackedFloat(num);
         return *this;
     }
 
-    inline void ToGmp(mpf_t num) {
+    inline void ToGmp(mpf_ptr num) {
         const size_t gmp_limbs = (mpf_get_prec(num) + 8 * sizeof(mp_limb_t) - 1) / (8 * sizeof(mp_limb_t));
         constexpr size_t kNumLimbs = kMantissaBytes / sizeof(Limb);
         // GMP does not allow graceful rounding, so we cannot handle having insufficient bits in the target GMP number


### PR DESCRIPTION
I believe we're abusing mpf_t slightly: 
- `mpf_t` is defined as `__mpf_struct[1]`.
- There is are types `mpf_ptr` and `mpf_srcptr` which are defined as `__mpf_struct*` or `const __mpf_struct*` respectively
- Everything in GMP takes `mpf_ptr` or `mpf_srcptr` which works because of pointer decay
- When the `__mpf_struct` gets copied as an argument, the side-effects on the mantissa should work fine but I don't think we should get _all_ side-effects
- I've only been poking around GMP, but I imagine MPFR is laid out in a similar way?