### PR TITLE
Free Running Kernel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ find_package(MPFR REQUIRED)
 find_package(GMP REQUIRED)
 find_package(Threads REQUIRED)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic -DAPFP_${APFP_SEMANTICS}_SEMANTICS")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic -Wno-unused-label -DAPFP_${APFP_SEMANTICS}_SEMANTICS")
 include_directories(${CMAKE_BINARY_DIR} include SYSTEM hlslib/include ${Vitis_INCLUDE_DIRS} )
 
 configure_file(include/Config.h.in Config.h)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,15 +1,16 @@
 cmake_minimum_required(VERSION 3.0)
 project(apfp)
-
+ 
 set(CMAKE_CXX_STANDARD 17)
 
 # Target options 
 set(APFP_PLATFORM "xilinx_u280_xdma_201920_3" CACHE STRING "Platform string for Vitis.")
 set(APFP_BITS 1024 CACHE STRING "Number of bits to use for a floating point number, including mantissa, exponent, and sign.")
-set(APFP_MULT_BASE_BITS 16 CACHE STRING "Number of bits to bottom out the multiplication at and use native multiplication.")
+set(APFP_MULT_BASE_BITS 18 CACHE STRING "Number of bits to bottom out the multiplication at and use native multiplication.")
 set(APFP_TILE_SIZE_N 32 CACHE STRING "Tile size in the N-dimension when running matrix-matrix multiplication.")
 set(APFP_TILE_SIZE_M 32 CACHE STRING "Tile size in the M-dimension when running matrix-matrix multiplication.")
 set(APFP_SEMANTICS "MPFR" CACHE STRING "Which semantics to use for floating point operations [GMP/MPFR].")
+set(APFP_PROFILING OFF CACHE BOOL "Enable profiling in the generated kernel.")
 set_property(CACHE APFP_SEMANTICS PROPERTY STRINGS GMP MPFR)
 
 # Validation and derived numbers
@@ -49,7 +50,7 @@ add_vitis_kernel(MatrixMultiplication FILES ${APFP_KERNEL_FILES}
                              m_axi_b:DDR[1]
                              m_axi_c_read:DDR[1]
                              m_axi_c_write:DDR[1])
-add_vitis_program(MatrixMultiplication ${APFP_PLATFORM})
+add_vitis_program(MatrixMultiplication ${APFP_PLATFORM} PROFILING ${APFP_PROFILING})
 
 # Internal library 
 add_library(apfp host/Random.cpp host/MatrixMultiplicationReference.cpp)

--- a/device/ArithmeticOperations.cpp
+++ b/device/ArithmeticOperations.cpp
@@ -54,6 +54,7 @@ PackedFloat Add(PackedFloat const &a, PackedFloat const &b) {
     // Optionally shift by 1, 2, 4, 8, 16... log2(B), such that all bits have eventually traveled to
     // their designated position.
     const int kNumStages = hlslib::ConstLog2(kBits);
+ShiftStages:
     for (int i = 0; i < kNumStages; ++i) {
 #pragma HLS UNROLL
         a_mantissa = ((shift_c & (1 << i)) == 0) ? a_mantissa : (a_mantissa >> (1 << i));

--- a/device/Karatsuba.cpp
+++ b/device/Karatsuba.cpp
@@ -2,6 +2,11 @@
 
 #include <type_traits>  // std::enable_if
 
+constexpr int AddLatency(int bits) {
+    // 4 is the maximum supported latency of integer adds using the BIND_OP pragma
+    return (bits >= 1024) ? 4 : (bits >= 768) ? 3 : (bits >= 512) ? 2 : (bits >= 256) ? 1 : 0;
+}
+
 template <int bits>
 auto _Karatsuba(ap_uint<bits> const &a, ap_uint<bits> const &b) ->
     typename std::enable_if<(bits > kMultBaseBits), ap_uint<2 * bits>>::type {
@@ -33,6 +38,7 @@ auto _Karatsuba(ap_uint<bits> const &a, ap_uint<bits> const &b) ->
     Full a0a1b0b1 = _Karatsuba<bits / 2>(a0a1, b0b1);
     ap_int<bits + 2> a0a1b0b1_signed = a0a1b0b1_is_neg ? -ap_int<bits + 1>(a0a1b0b1) : ap_int<bits + 2>(a0a1b0b1);
     ap_uint<bits + 2> z1 = ap_uint<bits + 2>(a0a1b0b1_signed) + z0 + z2;
+#pragma HLS BIND_OP variable = z1 op = add impl = fabric latency = AddLatency(bits)
 
     // Align everything and combine
     ap_uint<(2 * bits)> z0z2 = z0 | (ap_uint<(2 * bits)>(z2) << bits);
@@ -41,6 +47,7 @@ auto _Karatsuba(ap_uint<bits> const &a, ap_uint<bits> const &b) ->
     // Workaround to avoid HLS padding an extra bit for the add. This is necessary to support 2048 bit multiplication,
     // which required adding two 4096 numbers, because 4096 bits is the maximum width support by the ap_uint type.
     z.V = z1_aligned.V + z0z2.V;
+#pragma HLS BIND_OP variable = z.V op = add impl = fabric latency = AddLatency(bits)
 
     return z;
 }

--- a/device/MatrixMultiplication.cpp
+++ b/device/MatrixMultiplication.cpp
@@ -13,7 +13,9 @@ void ReadAInner(DramLine const *const mem, hlslib::Stream<PackedFloat> &a_to_fee
                 const int k) {
 #pragma HLS INLINE
     DramLine num[kLinesPerNumber];
+ReadA_N:
     for (int n1 = 0; n1 < kTileSizeN; ++n1) {
+    ReadA_Flits:
         for (int i = 0; i < kLinesPerNumber; ++i) {
 #pragma HLS PIPELINE II = 1
 #pragma HLS LOOP_FLATTEN
@@ -29,6 +31,7 @@ template <>
 void ReadAInner<1>(DramLine const *const mem, hlslib::Stream<PackedFloat> &a_to_feeder, const int size_k, const int n0,
                    const int k) {
 #pragma HLS INLINE
+ReadA_N:
     for (int n1 = 0; n1 < kTileSizeN; ++n1) {
 #pragma HLS PIPELINE II = 1
 #pragma HLS LOOP_FLATTEN
@@ -41,8 +44,11 @@ void ReadA(DramLine const *const mem, hlslib::Stream<PackedFloat> &a_to_feeder, 
            const int size_m) {
     const auto tiles_n = hlslib::CeilDivide(size_n, kTileSizeN);
     const auto tiles_m = hlslib::CeilDivide(size_m, kTileSizeM);
+ReadA_TilesN:
     for (int n0 = 0; n0 < tiles_n; ++n0) {
+    ReadA_TilesM:
         for (int m0 = 0; m0 < tiles_m; ++m0) {
+        ReadA_K:
             for (int k = 0; k < size_k; ++k) {
                 ReadAInner<kLinesPerNumber>(mem, a_to_feeder, size_k, n0, k);
             }
@@ -57,10 +63,15 @@ void FeedA(hlslib::Stream<PackedFloat> &a_to_feeder, hlslib::Stream<PackedFloat>
     const auto tiles_n = hlslib::CeilDivide(size_n, kTileSizeN);
     const auto tiles_m = hlslib::CeilDivide(size_m, kTileSizeM);
     PackedFloat a;
+FeedA_TilesN:
     for (int n0 = 0; n0 < tiles_n; ++n0) {
+    FeedA_TilesM:
         for (int m0 = 0; m0 < tiles_m; ++m0) {
+        FeedA_K:
             for (int k = 0; k < size_k; ++k) {
+            FeedA_N:
                 for (int n1 = 0; n1 < kTileSizeN; ++n1) {
+                FeedA_M:
                     for (int m1 = 0; m1 < kTileSizeM; ++m1) {
 #pragma HLS PIPELINE II = 1
 #pragma HLS LOOP_FLATTEN
@@ -82,7 +93,9 @@ void ReadBInner(DramLine const *const mem, hlslib::Stream<PackedFloat> &b_to_fee
                 const int k) {
 #pragma HLS INLINE
     DramLine num[kLinesPerNumber];
+ReadB_M:
     for (int m1 = 0; m1 < kTileSizeM; ++m1) {
+    ReadB_Flits:
         for (int i = 0; i < kLinesPerNumber; ++i) {
 #pragma HLS PIPELINE II = 1
 #pragma HLS LOOP_FLATTEN
@@ -98,6 +111,7 @@ template <>
 void ReadBInner<1>(DramLine const *const mem, hlslib::Stream<PackedFloat> &b_to_feeder, const int size_m, const int m0,
                    const int k) {
 #pragma HLS INLINE
+ReadB_M:
     for (int m1 = 0; m1 < kTileSizeM; ++m1) {
 #pragma HLS PIPELINE II = 1
 #pragma HLS LOOP_FLATTEN
@@ -110,8 +124,11 @@ void ReadB(DramLine const *const mem, hlslib::Stream<PackedFloat> &b_to_feeder, 
            const int size_m) {
     const auto tiles_n = hlslib::CeilDivide(size_n, kTileSizeN);
     const auto tiles_m = hlslib::CeilDivide(size_m, kTileSizeM);
+ReadB_TilesN:
     for (int n0 = 0; n0 < tiles_n; ++n0) {
+    ReadB_TilesM:
         for (int m0 = 0; m0 < tiles_m; ++m0) {
+        ReadB_K:
             for (int k = 0; k < size_k; ++k) {
                 ReadBInner<kLinesPerNumber>(mem, b_to_feeder, size_m, m0, k);
             }
@@ -124,10 +141,15 @@ void FeedB(hlslib::Stream<PackedFloat> &b_to_feeder, hlslib::Stream<PackedFloat>
     const auto tiles_n = hlslib::CeilDivide(size_n, kTileSizeN);
     const auto tiles_m = hlslib::CeilDivide(size_m, kTileSizeM);
     PackedFloat b;
+FeedB_TilesN:
     for (int n0 = 0; n0 < tiles_n; ++n0) {
+    FeedB_TilesM:
         for (int m0 = 0; m0 < tiles_m; ++m0) {
+        FeedB_K:
             for (int k = 0; k < size_k; ++k) {
+            FeedB_N:
                 for (int n1 = 0; n1 < kTileSizeN; ++n1) {
+                FeedB_M:
                     for (int m1 = 0; m1 < kTileSizeM; ++m1) {
 #pragma HLS PIPELINE II = 1
 #pragma HLS LOOP_FLATTEN
@@ -148,8 +170,10 @@ template <int lines_per_number>
 void ReadCInner(DramLine const *const mem, hlslib::Stream<PackedFloat> &c_to_feeder, const int size_m, const int n0,
                 const int m0, const int n1) {
 #pragma HLS INLINE
+ReadC_M:
     for (int m1 = 0; m1 < kTileSizeM; ++m1) {
         DramLine num[kLinesPerNumber];
+    ReadC_Flits:
         for (int i = 0; i < kLinesPerNumber; ++i) {
 #pragma HLS PIPELINE II = 1
 #pragma HLS LOOP_FLATTEN
@@ -165,6 +189,7 @@ template <>
 void ReadCInner<1>(DramLine const *const mem, hlslib::Stream<PackedFloat> &c_to_feeder, const int size_m, const int n0,
                    const int m0, const int n1) {
 #pragma HLS INLINE
+ReadC_M:
     for (int m1 = 0; m1 < kTileSizeM; ++m1) {
 #pragma HLS PIPELINE II = 1
 #pragma HLS LOOP_FLATTEN
@@ -176,8 +201,11 @@ void ReadCInner<1>(DramLine const *const mem, hlslib::Stream<PackedFloat> &c_to_
 void ReadC(DramLine const *const mem, hlslib::Stream<PackedFloat> &c_to_feeder, const int size_n, const int size_m) {
     const auto tiles_n = hlslib::CeilDivide(size_n, kTileSizeN);
     const auto tiles_m = hlslib::CeilDivide(size_m, kTileSizeM);
+ReadC_TilesN:
     for (int n0 = 0; n0 < tiles_n; ++n0) {
+    ReadC_TilesM:
         for (int m0 = 0; m0 < tiles_m; ++m0) {
+        ReadC_N:
             for (int n1 = 0; n1 < kTileSizeN; ++n1) {
                 ReadCInner<kLinesPerNumber>(mem, c_to_feeder, size_m, n0, m0, n1);
             }
@@ -190,10 +218,15 @@ void FeedC(hlslib::Stream<PackedFloat> &c_to_feeder, hlslib::Stream<PackedFloat>
     const auto tiles_n = hlslib::CeilDivide(size_n, kTileSizeN);
     const auto tiles_m = hlslib::CeilDivide(size_m, kTileSizeM);
     PackedFloat c;
+FeedC_TilesN:
     for (int n0 = 0; n0 < tiles_n; ++n0) {
+    FeedC_TilesM:
         for (int m0 = 0; m0 < tiles_m; ++m0) {
+        FeedC_K:
             for (int k = 0; k < size_k; ++k) {
+            FeedC_N:
                 for (int n1 = 0; n1 < kTileSizeN; ++n1) {
+                FeedC_M:
                     for (int m1 = 0; m1 < kTileSizeM; ++m1) {
 #pragma HLS PIPELINE II = 1
 #pragma HLS LOOP_FLATTEN
@@ -214,10 +247,15 @@ void DrainC(hlslib::Stream<PackedFloat> &c_to_drainer, hlslib::Stream<PackedFloa
             const int size_m, const int size_k) {
     const auto tiles_n = hlslib::CeilDivide(size_n, kTileSizeN);
     const auto tiles_m = hlslib::CeilDivide(size_m, kTileSizeM);
+DrainC_TilesN:
     for (int n0 = 0; n0 < tiles_n; ++n0) {
+    DrainC_TilesM:
         for (int m0 = 0; m0 < tiles_m; ++m0) {
+        DrainC_K:
             for (int k = 0; k < size_k; ++k) {
+            DrainC_N:
                 for (int n1 = 0; n1 < kTileSizeN; ++n1) {
+                DrainC_M:
                     for (int m1 = 0; m1 < kTileSizeM; ++m1) {
 #pragma HLS PIPELINE II = 1
 #pragma HLS LOOP_FLATTEN
@@ -236,9 +274,11 @@ template <int lines_per_number>
 void WriteCInner(hlslib::Stream<PackedFloat> &from_kernel, DramLine *const mem, const int size_m, const int n0,
                  const int m0, const int n1) {
 #pragma HLS INLINE
+WriteC_M:
     for (int m1 = 0; m1 < kTileSizeM; ++m1) {
         DramLine num[kLinesPerNumber];
 #pragma HLS ARRAY_PARTITION variable = num complete
+    WriteC_Flits:
         for (int i = 0; i < kLinesPerNumber; ++i) {
 #pragma HLS PIPELINE II = 1
 #pragma HLS LOOP_FLATTEN
@@ -254,6 +294,7 @@ template <>
 void WriteCInner<1>(hlslib::Stream<PackedFloat> &from_kernel, DramLine *const mem, const int size_m, const int n0,
                     const int m0, const int n1) {
 #pragma HLS INLINE
+WriteC_M:
     for (int m1 = 0; m1 < kTileSizeM; ++m1) {
 #pragma HLS PIPELINE II = 1
 #pragma HLS LOOP_FLATTEN
@@ -264,8 +305,13 @@ void WriteCInner<1>(hlslib::Stream<PackedFloat> &from_kernel, DramLine *const me
 }
 
 void WriteC(hlslib::Stream<PackedFloat> &from_kernel, DramLine *const mem, const int size_n, int const size_m) {
-    for (int n0 = 0; n0 < hlslib::CeilDivide(size_n, kTileSizeN); ++n0) {
-        for (int m0 = 0; m0 < hlslib::CeilDivide(size_m, kTileSizeM); ++m0) {
+    const auto tiles_n = hlslib::CeilDivide(size_n, kTileSizeN);
+    const auto tiles_m = hlslib::CeilDivide(size_m, kTileSizeM);
+WriteC_TilesN:
+    for (int n0 = 0; n0 < tiles_n; ++n0) {
+    WriteC_TilesM:
+        for (int m0 = 0; m0 < tiles_m; ++m0) {
+        WriteC_N:
             for (int n1 = 0; n1 < kTileSizeN; ++n1) {
                 WriteCInner<kLinesPerNumber>(from_kernel, mem, size_m, n0, m0, n1);
             }
@@ -280,10 +326,15 @@ void Compute(hlslib::Stream<PackedFloat> &a_in, hlslib::Stream<PackedFloat> &b_i
     PackedFloat a_buffer;  // Just to make A symmetric to B and C
     PackedFloat b_buffer[kTileSizeM];
     PackedFloat c_buffer[kTileSizeN * kTileSizeM];
+Compute_TilesN:
     for (int n0 = 0; n0 < hlslib::CeilDivide(size_n, kTileSizeN); ++n0) {
+    Compute_TilesM:
         for (int m0 = 0; m0 < hlslib::CeilDivide(size_m, kTileSizeM); ++m0) {
+        Compute_K:
             for (int k = 0; k < size_k; ++k) {
+            Compute_N:
                 for (int n1 = 0; n1 < kTileSizeN; ++n1) {
+                Compute_M:
                     for (int m1 = 0; m1 < kTileSizeM; ++m1) {
 #pragma HLS PIPELINE II = 1
 #pragma HLS LOOP_FLATTEN

--- a/device/MatrixMultiplication.cpp
+++ b/device/MatrixMultiplication.cpp
@@ -59,7 +59,7 @@ ReadA_TilesN:
 // In order to eliminate control logic in the compute function, we introduce extra feeders that run in the iteration
 // space of the computational module, but write to the kernel every iteration to absorb the conditional pipeline reads
 void FeedA(hlslib::Stream<PackedFloat> &a_to_feeder, hlslib::Stream<PackedFloat> &a_to_kernel, const int size_n,
-           const int size_m, const int size_k) {
+           const int size_k, const int size_m) {
     const auto tiles_n = hlslib::CeilDivide(size_n, kTileSizeN);
     const auto tiles_m = hlslib::CeilDivide(size_m, kTileSizeM);
     PackedFloat a;
@@ -137,7 +137,7 @@ ReadB_TilesN:
 }
 
 void FeedB(hlslib::Stream<PackedFloat> &b_to_feeder, hlslib::Stream<PackedFloat> &b_to_kernel, const int size_n,
-           const int size_m, const int size_k) {
+           const int size_k, const int size_m) {
     const auto tiles_n = hlslib::CeilDivide(size_n, kTileSizeN);
     const auto tiles_m = hlslib::CeilDivide(size_m, kTileSizeM);
     PackedFloat b;
@@ -214,7 +214,7 @@ ReadC_TilesN:
 }
 
 void FeedC(hlslib::Stream<PackedFloat> &c_to_feeder, hlslib::Stream<PackedFloat> &c_to_kernel, const int size_n,
-           const int size_m, const int size_k) {
+           const int size_k, const int size_m) {
     const auto tiles_n = hlslib::CeilDivide(size_n, kTileSizeN);
     const auto tiles_m = hlslib::CeilDivide(size_m, kTileSizeM);
     PackedFloat c;
@@ -244,7 +244,7 @@ FeedC_TilesN:
 ////////////////////////////////////////////////////////////////////////////////
 
 void DrainC(hlslib::Stream<PackedFloat> &c_to_drainer, hlslib::Stream<PackedFloat> &drainer_to_c, const int size_n,
-            const int size_m, const int size_k) {
+            const int size_k, const int size_m) {
     const auto tiles_n = hlslib::CeilDivide(size_n, kTileSizeN);
     const auto tiles_m = hlslib::CeilDivide(size_m, kTileSizeM);
 DrainC_TilesN:
@@ -326,10 +326,12 @@ void Compute(hlslib::Stream<PackedFloat> &a_in, hlslib::Stream<PackedFloat> &b_i
     PackedFloat a_buffer;  // Just to make A symmetric to B and C
     PackedFloat b_buffer[kTileSizeM];
     PackedFloat c_buffer[kTileSizeN * kTileSizeM];
+    const int tiles_n = hlslib::CeilDivide(size_n, kTileSizeN);
+    const int tiles_m = hlslib::CeilDivide(size_m, kTileSizeM);
 Compute_TilesN:
-    for (int n0 = 0; n0 < hlslib::CeilDivide(size_n, kTileSizeN); ++n0) {
+    for (int n0 = 0; n0 < tiles_n; ++n0) {
     Compute_TilesM:
-        for (int m0 = 0; m0 < hlslib::CeilDivide(size_m, kTileSizeM); ++m0) {
+        for (int m0 = 0; m0 < tiles_m; ++m0) {
         Compute_K:
             for (int k = 0; k < size_k; ++k) {
             Compute_N:

--- a/host/Random.cpp
+++ b/host/Random.cpp
@@ -24,7 +24,7 @@ __mpf_struct RandomNumberGenerator::GenerateGmp() {
 
 __mpfr_struct RandomNumberGenerator::GenerateMpfr() {
     mpfr_t num;
-    mpfr_init2(num, kBits);
+    mpfr_init2(num, kMantissaBits);
     Generate(num);
     return num[0];
 }

--- a/host/TestProgram.cpp
+++ b/host/TestProgram.cpp
@@ -107,6 +107,7 @@ bool RunTest(std::string const &kernel_path, int size_n, int size_k, int size_m)
             }
         }
     }
+    std::cout << "Results successfully verified against MPFR.\n";
 
     // Clean up
     for (int n = 0; n < size_n; ++n) {

--- a/host/TestProgram.cpp
+++ b/host/TestProgram.cpp
@@ -69,9 +69,11 @@ bool RunTest(std::string const &kernel_path, int size_n, int size_k, int size_m)
     std::cout << "Executing kernel...\n";
     const auto elapsed = kernel.ExecuteTask();
     std::cout << "Ran in " << elapsed.first << " seconds.\n";
-    const unsigned long ideal_cycles =
-        hlslib::CeilDivide(size_n, kTileSizeN) * hlslib::CeilDivide(size_m, kTileSizeM) * kTileSizeN * kTileSizeM;
-    std::cout << "The ideal number of cycles to completion is " << ideal_cycles << ".\n";
+    const unsigned long expected_cycles = hlslib::CeilDivide(size_n, kTileSizeN) *
+                                          hlslib::CeilDivide(size_m, kTileSizeM) * kTileSizeN * kTileSizeM * size_k;
+    const float expected_runtime = expected_cycles / 0.3e9;
+    std::cout << "The expected number of cycles to completion is " << expected_cycles << ", which is "
+              << expected_runtime << " seconds at 300 MHz.\n";
     // Copy back result
     c_device.CopyToHost(0, kLinesPerNumber * size_n * size_m, reinterpret_cast<DramLine *>(&c_host[0]));
     // Run reference implementation. Because of GMP's "clever" way of wrapping their struct in an array of size 1,


### PR DESCRIPTION
In this PR:
- Made the core computation of matrix multiplication a free running kernel, by moving the control flow on the FIFOs out into separate feeder and drainer function.
- Introduced more cycles of latency to the adds in Karatsuba to help place and route
- Fixed an issue with initializing floats in `Random.cpp`
- Add some more diagnostics to the kernel test function