### PR TITLE
No mpfr struct

### DIFF
--- a/host/Random.cpp
+++ b/host/Random.cpp
@@ -9,32 +9,27 @@ RandomNumberGenerator::~RandomNumberGenerator() {
 }
 
 PackedFloat RandomNumberGenerator::Generate() {
-    mpfr_t mpfr_num = {GenerateMpfr()};
+    mpfr_t mpfr_num;
+    GenerateMpfr(mpfr_num);
     PackedFloat num(mpfr_num);
     mpfr_clear(mpfr_num);
     return num;
 }
 
-__mpf_struct RandomNumberGenerator::GenerateGmp() {
-    mpf_t num;
+void RandomNumberGenerator::GenerateGmp(mpf_ptr num) {
     mpf_init2(num, kMantissaBits);
-    Generate(num);
-    return num[0];
 }
 
-__mpfr_struct RandomNumberGenerator::GenerateMpfr() {
-    mpfr_t num;
+void RandomNumberGenerator::GenerateMpfr(mpfr_ptr num) {
     mpfr_init2(num, kMantissaBits);
-    Generate(num);
-    return num[0];
 }
 
-void RandomNumberGenerator::Generate(mpfr_t &num) {
+void RandomNumberGenerator::Generate(mpfr_ptr num) {
     std::unique_lock<std::mutex> lock(mutex_);
     mpfr_urandom(num, state_, kRoundingMode);
 }
 
-void RandomNumberGenerator::Generate(mpf_t &num) {
+void RandomNumberGenerator::Generate(mpf_ptr num) {
     std::unique_lock<std::mutex> lock(mutex_);
     mpf_urandomb(num, state_, kMantissaBits);
 }

--- a/host/Random.cpp
+++ b/host/Random.cpp
@@ -18,10 +18,12 @@ PackedFloat RandomNumberGenerator::Generate() {
 
 void RandomNumberGenerator::GenerateGmp(mpf_ptr num) {
     mpf_init2(num, kMantissaBits);
+    Generate(num);
 }
 
 void RandomNumberGenerator::GenerateMpfr(mpfr_ptr num) {
     mpfr_init2(num, kMantissaBits);
+    Generate(num);
 }
 
 void RandomNumberGenerator::Generate(mpfr_ptr num) {

--- a/include/PackedFloat.h
+++ b/include/PackedFloat.h
@@ -67,7 +67,7 @@ class PackedFloat {
         sign = num->_mp_size < 0;  // 1 if negative, 0 otherwise
     }
 
-    inline PackedFloat(const mpfr_t num) {
+    inline PackedFloat(const mpfr_srcptr num) {
         // Copy the most significant bytes, padding zeros if necessary
         const auto mpfr_limbs = (mpfr_get_prec(num) + 8 * sizeof(mp_limb_t) - 1) / (8 * sizeof(mp_limb_t));
         const size_t mpfr_bytes = mpfr_limbs * sizeof(mp_limb_t);
@@ -104,7 +104,7 @@ class PackedFloat {
         }
     }
 
-    inline void ToMpfr(mpfr_t num) {
+    inline void ToMpfr(mpfr_ptr num) const {
         // Copy the most significant bytes, padding zeros if necessary
         const auto mpfr_limbs = (mpfr_get_prec(num) + 8 * sizeof(mp_limb_t) - 1) / (8 * sizeof(mp_limb_t));
         const size_t mpfr_bytes = mpfr_limbs * sizeof(mp_limb_t);

--- a/include/Random.h
+++ b/include/Random.h
@@ -20,16 +20,16 @@ class RandomNumberGenerator {
     PackedFloat Generate();
 
     /// Generate a random GMP number.
-    __mpf_struct GenerateGmp();
+    void GenerateGmp(mpf_ptr);
 
     /// Generate a random GMP number into the specified output variable.
-    void Generate(mpf_t &);
+    void Generate(mpf_ptr);
 
     /// Generate a random MPFR number.
-    __mpfr_struct GenerateMpfr();
+    void GenerateMpfr(mpfr_ptr);
 
     /// Generate a random MPFR into the specified output variable.
-    void Generate(mpfr_t &);
+    void Generate(mpfr_ptr);
 
    private:
     gmp_randstate_t state_;


### PR DESCRIPTION
This removes the direct usage of the `__mpfr_struct` type in the tests. I am slightly worried that we might have been relying on some undefined behavior somewhere in the test by copying `__mpfr_struct`, so I removed the usage