### PR TITLE
Support Multiple Compute Units

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ set(APFP_BITS 1024 CACHE STRING "Number of bits to use for a floating point numb
 set(APFP_MULT_BASE_BITS 18 CACHE STRING "Number of bits to bottom out the multiplication at and use native multiplication.")
 set(APFP_TILE_SIZE_N 32 CACHE STRING "Tile size in the N-dimension when running matrix-matrix multiplication.")
 set(APFP_TILE_SIZE_M 32 CACHE STRING "Tile size in the M-dimension when running matrix-matrix multiplication.")
+set(APFP_COMPUTE_UNITS 1 CACHE STRING "Number of replications of the kernel to instantiate.")
 set(APFP_SEMANTICS "MPFR" CACHE STRING "Which semantics to use for floating point operations [GMP/MPFR].")
 set(APFP_DEBUGGING OFF CACHE BOOL "Enable debugging in generated kernels.")
 set(APFP_PROFILING OFF CACHE BOOL "Enable profiling in generated kernels.")
@@ -28,9 +29,8 @@ find_package(Vitis REQUIRED)
 find_package(MPFR REQUIRED)
 find_package(GMP REQUIRED)
 find_package(Threads REQUIRED)
-find_package(OpenMP)  # This is just for running MPFR, so leave as optional
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic -Wno-unused-label -Wno-class-memaccess -Wno-unknown-pragmas -DAPFP_${APFP_SEMANTICS}_SEMANTICS ${OpenMP_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic -Wno-unused-label -Wno-class-memaccess -Wno-unknown-pragmas -DAPFP_${APFP_SEMANTICS}_SEMANTICS")
 include_directories(${CMAKE_BINARY_DIR} include SYSTEM hlslib/include ${Vitis_INCLUDE_DIRS} )
 
 configure_file(include/Config.h.in Config.h)
@@ -39,8 +39,39 @@ set(APFP_KERNEL_FILES device/MatrixMultiplication.cpp
                       device/ArithmeticOperations.cpp
                       device/Karatsuba.cpp)
 
+# Mapping to DDR ports
+set(APFP_PORT_MAPPING MatrixMultiplication_1.m_axi_a:DDR[1]
+                      MatrixMultiplication_1.m_axi_b:DDR[1]
+                      MatrixMultiplication_1.m_axi_c_read:DDR[1]
+                      MatrixMultiplication_1.m_axi_c_write:DDR[1])
+if(${APFP_COMPUTE_UNITS} GREATER 1)
+    set(APFP_PORT_MAPPING ${APFP_PORT_MAPPING}
+                          MatrixMultiplication_2.m_axi_a:DDR[0]
+                          MatrixMultiplication_2.m_axi_b:DDR[0]
+                          MatrixMultiplication_2.m_axi_c_read:DDR[0]
+                          MatrixMultiplication_2.m_axi_c_write:DDR[0])
+endif()
+if(${APFP_COMPUTE_UNITS} GREATER 2)
+    set(APFP_PORT_MAPPING ${APFP_PORT_MAPPING}
+                          MatrixMultiplication_3.m_axi_a:DDR[2]
+                          MatrixMultiplication_3.m_axi_b:DDR[2]
+                          MatrixMultiplication_3.m_axi_c_read:DDR[2]
+                          MatrixMultiplication_3.m_axi_c_write:DDR[2])
+endif()
+if(${APFP_COMPUTE_UNITS} GREATER 3)
+    set(APFP_PORT_MAPPING ${APFP_PORT_MAPPING}
+                          MatrixMultiplication_4.m_axi_a:DDR[3]
+                          MatrixMultiplication_4.m_axi_b:DDR[3]
+                          MatrixMultiplication_4.m_axi_c_read:DDR[3]
+                          MatrixMultiplication_4.m_axi_c_write:DDR[3])
+endif()
+if(${APFP_COMPUTE_UNITS} GREATER 4)
+    message(FATAL_ERROR "More than 4 compute units is not supported.")
+endif()
+
 # Setup FPGA kernel targets
 add_vitis_kernel(MatrixMultiplication FILES ${APFP_KERNEL_FILES}
+                 COMPUTE_UNITS ${APFP_COMPUTE_UNITS}
                  INCLUDE_DIRS include hlslib/include ${CMAKE_BINARY_DIR}
                  HLS_FLAGS "-DAP_INT_MAX_W=${APFP_MAX_BITS} -DAPFP_${APFP_SEMANTICS}_SEMANTICS"
                  HLS_CONFIG "config_compile -pipeline_style frp\nconfig_dataflow -fifo_depth 16"
@@ -51,10 +82,7 @@ add_vitis_kernel(MatrixMultiplication FILES ${APFP_KERNEL_FILES}
                          include/MatrixMultiplication.h
                          include/PackedFloat.h
                          include/PipelinedAdd.h
-                PORT_MAPPING m_axi_a:DDR[1]
-                             m_axi_b:DDR[1]
-                             m_axi_c_read:DDR[1]
-                             m_axi_c_write:DDR[1])
+                PORT_MAPPING ${APFP_PORT_MAPPING})
 add_vitis_program(MatrixMultiplication ${APFP_PLATFORM}
                   PROFILING ${APFP_PROFILING}
                   DEBUGGING ${APFP_DEBUGGING}
@@ -62,7 +90,7 @@ add_vitis_program(MatrixMultiplication ${APFP_PLATFORM}
 
 # Internal library 
 add_library(apfp host/Random.cpp host/MatrixMultiplicationReference.cpp)
-target_link_libraries(apfp ${GMP_LIBRARIES} ${MPFR_LIBRARIES} ${OpenMP_CXX_LIBRARIES})
+target_link_libraries(apfp ${GMP_LIBRARIES} ${MPFR_LIBRARIES})
 
 # Library necessary to run in simulation mode
 add_library(simulation ${APFP_KERNEL_FILES})

--- a/host/TestProgram.cpp
+++ b/host/TestProgram.cpp
@@ -27,10 +27,12 @@ bool RunTestSimulation(int size_n, int size_k, int size_m, bool verify) {
 #else
 bool RunTest(std::string const &kernel_path, int size_n, int size_k, int size_m, bool verify) {
 #endif
+
     hlslib::ocl::Context context;
     std::cout << "Configuring the device..." << std::flush;
     auto program = context.MakeProgram(kernel_path);
     std::cout << " Done.\n";
+
     // Initialize some random data
     std::cout << "Initializing input data..." << std::flush;
     std::vector<MpfrWrapper> a_mpfr, b_mpfr, c_mpfr;
@@ -65,6 +67,22 @@ bool RunTest(std::string const &kernel_path, int size_n, int size_k, int size_m,
         c_host.emplace_back(x);
     }
     std::cout << " Done.\n";
+
+    // Compute partitions
+    int n_begin[kComputeUnits];
+    int n_end[kComputeUnits];
+    int n_partition_size[kComputeUnits];
+    unsigned long expected_cycles = 0;
+    for (int i = 0; i < kComputeUnits; ++i) {
+        n_begin[i] = (i * size_n) / kComputeUnits;
+        n_end[i] = ((i + 1) * size_n) / kComputeUnits;
+        n_partition_size[i] = n_end[i] - n_begin[i];
+        expected_cycles =
+            std::max(expected_cycles,
+                     (unsigned long)(hlslib::CeilDivide(n_partition_size[i], kTileSizeN) *
+                                     hlslib::CeilDivide(size_m, kTileSizeM) * kTileSizeN * kTileSizeM * size_k));
+    }
+
     // Allocate device memory, padding each buffer to the tile size
     std::cout << "Copying data to the device..." << std::flush;
     constexpr int kDramMapping[] = {1, 0, 2, 3};
@@ -72,35 +90,40 @@ bool RunTest(std::string const &kernel_path, int size_n, int size_k, int size_m,
     std::vector<hlslib::ocl::Buffer<DramLine, hlslib::ocl::Access::read>> b_device;
     std::vector<hlslib::ocl::Buffer<DramLine, hlslib::ocl::Access::readWrite>> c_device;
     for (int i = 0; i < kComputeUnits; ++i) {
-        a_device.emplace_back(context, hlslib::ocl::StorageType::DDR, kDramMapping[i],
-                              kLinesPerNumber * (hlslib::CeilDivide(size_n, kTileSizeN) * kTileSizeN) * size_k);
+        a_device.emplace_back(
+            context, hlslib::ocl::StorageType::DDR, kDramMapping[i],
+            kLinesPerNumber * (hlslib::CeilDivide(n_partition_size[i], kTileSizeN) * kTileSizeN) * size_k);
         b_device.emplace_back(context, hlslib::ocl::StorageType::DDR, kDramMapping[i],
                               kLinesPerNumber * size_k * (hlslib::CeilDivide(size_m, kTileSizeM) * kTileSizeM));
         c_device.emplace_back(context, hlslib::ocl::StorageType::DDR, kDramMapping[i],
-                              kLinesPerNumber * (hlslib::CeilDivide(size_n, kTileSizeN) * kTileSizeN) *
+                              kLinesPerNumber * (hlslib::CeilDivide(n_partition_size[i], kTileSizeN) * kTileSizeN) *
                                   (hlslib::CeilDivide(size_m, kTileSizeM) * kTileSizeM));
         // Copy data to the accelerator cast to 512-bit DRAM lines
-        a_device[i].CopyFromHost(0, kLinesPerNumber * size_n * size_k, reinterpret_cast<DramLine const *>(&a_host[0]));
+        a_device[i].CopyFromHost(0, kLinesPerNumber * n_partition_size[i] * size_k,
+                                 reinterpret_cast<DramLine const *>(&a_host[n_begin[i] * size_k]));
         b_device[i].CopyFromHost(0, kLinesPerNumber * size_k * size_m, reinterpret_cast<DramLine const *>(&b_host[0]));
-        c_device[i].CopyFromHost(0, kLinesPerNumber * size_n * size_m, reinterpret_cast<DramLine const *>(&c_host[0]));
+        c_device[i].CopyFromHost(0, kLinesPerNumber * n_partition_size[i] * size_m,
+                                 reinterpret_cast<DramLine const *>(&c_host[n_begin[i] * size_m]));
     }
     std::cout << " Done.\n";
+
     // In simulation mode, this will call the function "MatrixMultiplication" and run it in software.
     // Otherwise, the provided path to a kernel binary will be loaded and executed.
     std::vector<hlslib::ocl::Kernel> kernels;
     for (int i = 0; i < kComputeUnits; ++i) {
         kernels.emplace_back(program.MakeKernel(MatrixMultiplication, "MatrixMultiplication", a_device[i], b_device[i],
-                                                c_device[i], c_device[i], size_n, size_k, size_m));
+                                                c_device[i], c_device[i], n_partition_size[i], size_k, size_m));
     }
-    const unsigned long expected_cycles = hlslib::CeilDivide(size_n, kTileSizeN) *
-                                          hlslib::CeilDivide(size_m, kTileSizeM) * kTileSizeN * kTileSizeM * size_k;
+
     const float expected_runtime = expected_cycles / 0.3e9;
     std::cout << "The expected number of cycles to completion is " << expected_cycles << ", which is "
               << expected_runtime << " seconds at 300 MHz.\n";
     const auto communication_volume = hlslib::CeilDivide(size_n, kTileSizeN) * hlslib::CeilDivide(size_m, kTileSizeM) *
                                       ((kTileSizeN + kTileSizeM) * size_k + 2 * kTileSizeN * kTileSizeM);
+    const auto bandwidth = 1e-9 * kBytes * communication_volume / expected_runtime;
     std::cout << "This communicates " << 1e-6 * kBytes * communication_volume << " MB, requiring a bandwidth of "
-              << 1e-9 * kBytes * communication_volume / expected_runtime << " GB/s.\n";
+              << bandwidth << " GB/s.\n";
+
     std::cout << "Executing kernel...\n";
     std::vector<hlslib::ocl::Event> events;
     auto start = std::chrono::high_resolution_clock::now();
@@ -118,9 +141,10 @@ bool RunTest(std::string const &kernel_path, int size_n, int size_k, int size_m,
 
     // Copy back result
     std::cout << "Copying back result..." << std::flush;
-    std::vector<std::vector<PackedFloat>> results(kComputeUnits, std::vector<PackedFloat>(size_n * size_m));
+    std::vector<PackedFloat> result(size_n * size_m);
     for (int i = 0; i < kComputeUnits; ++i) {
-        c_device[i].CopyToHost(0, kLinesPerNumber * size_n * size_m, reinterpret_cast<DramLine *>(&results[i][0]));
+        c_device[i].CopyToHost(0, kLinesPerNumber * n_partition_size[i] * size_m,
+                               reinterpret_cast<DramLine *>(&result[n_begin[i] * size_m]));
     }
     std::cout << "Done.\n";
 
@@ -136,21 +160,13 @@ bool RunTest(std::string const &kernel_path, int size_n, int size_k, int size_m,
     std::cout << "Ran in " << elapsed_reference << " seconds.\n";
 
     // Verify results
-    for (int i = 0; i < kComputeUnits; ++i) {
-        for (int n = 0; n < size_n; ++n) {
-            for (int m = 0; m < size_m; ++m) {
-                const PackedFloat res = results[i][n * size_m + m];
-                const PackedFloat ref(c_mpfr[n * size_m + m]);
-                if (ref != res) {
-                    if (kComputeUnits <= 1) {
-                        std::cerr << "Verification failed at (" << n << ", " << m << "):\n\t" << res << "\n\t" << ref
-                                  << "\n";
-                    } else {
-                        std::cerr << "Verification failed for compute unit " << i << " at (" << n << ", " << m
-                                  << "):\n\t" << res << "\n\t" << ref << "\n";
-                    }
-                    return false;
-                }
+    for (int n = 0; n < size_n; ++n) {
+        for (int m = 0; m < size_m; ++m) {
+            const PackedFloat res = result[n * size_m + m];
+            const PackedFloat ref(c_mpfr[n * size_m + m]);
+            if (ref != res) {
+                std::cerr << "Verification failed at (" << n << ", " << m << "):\n\t" << res << "\n\t" << ref << "\n";
+                return false;
             }
         }
     }

--- a/include/Config.h.in
+++ b/include/Config.h.in
@@ -5,5 +5,6 @@ constexpr int kBytes = kBits / 8;
 constexpr int kMultBaseBits = ${APFP_MULT_BASE_BITS};
 constexpr int kTileSizeN = ${APFP_TILE_SIZE_N};
 constexpr int kTileSizeM = ${APFP_TILE_SIZE_M};
+constexpr int kComputeUnits = ${APFP_COMPUTE_UNITS};
 constexpr auto kBuildDir = "${CMAKE_BINARY_DIR}";
 static_assert(kBits % 8 == 0, "Number of bits must be byte-aligned.");


### PR DESCRIPTION
These are instantiated as independent matrix multipliers. By partitioning the input and output matrices, these can be used to solve a combined matrix multiplication.