### PR TITLE
Add PipelinedSub (carry_in PipelinedAdd)

### DIFF
--- a/device/ArithmeticOperations.cpp
+++ b/device/ArithmeticOperations.cpp
@@ -110,7 +110,7 @@ PackedFloat Add(PackedFloat const &a_in, PackedFloat const &b_in) {
     // Widening assignments and right shifts of ap_int are sign extended so we specify the casting route
     assert(a_mantissa_shifted >= b_mantissa_shifted);
     ap_uint<kMantissaBits + 1 + lsb_bits> ab_diff_lsb_msb =
-        static_cast<ap_uint<kMantissaBits + 1 + lsb_bits>>(a_mantissa_shifted - b_mantissa_shifted);
+        static_cast<ap_uint<kMantissaBits + 1 + lsb_bits>>(PipelinedSub(a_mantissa_shifted, b_mantissa_shifted));
 #pragma HLS BIND_OP variable = ab_diff_lsb_msb op = sub impl = fabric latency = 4
     assert(!IsMostSignificantBitSet(ab_diff_lsb_msb));
 

--- a/device/Karatsuba.cpp
+++ b/device/Karatsuba.cpp
@@ -23,11 +23,11 @@ auto _Karatsuba(ap_uint<bits> const &a, ap_uint<bits> const &b) ->
 
     // Compute |a_0 - a_1| and sign(a_0 - a_1)
     bool a0a1_is_neg = a0 < a1;
-    Half a0a1 = a0a1_is_neg ? (a1 - a0) : (a0 - a1);
+    Half a0a1 = PipelinedSub(a0a1_is_neg ? a1 : a0, a0a1_is_neg ? a0 : a1);
 #pragma HLS BIND_OP variable = a0a1 op = sub impl = fabric latency = AddLatency(bits / 2)
     // Compute |b_1 - b_0| and sign(b_1 - b_0)
     bool b0b1_is_neg = b1 < b0;
-    Half b0b1 = b0b1_is_neg ? (b0 - b1) : (b1 - b0);
+    Half b0b1 = PipelinedSub(b0b1_is_neg ? b0 : b1, b0b1_is_neg ? b1 : b0);
 #pragma HLS BIND_OP variable = b0b1 op = sub impl = fabric latency = AddLatency(bits / 2)
 
     // XOR the two signs to get the final sign

--- a/include/PipelinedAdd.h
+++ b/include/PipelinedAdd.h
@@ -18,13 +18,13 @@ struct _PipelinedAddImpl {
     static constexpr int bit_begin = ((step - 1) * total_bits) / num_steps;
     static constexpr int bits = bit_end - bit_begin;
 
-    static bool Apply(ap_uint<total_bits> const &a, ap_uint<total_bits> const &b, ap_uint<total_bits + 1> &result) {
+    static bool Apply(ap_uint<total_bits> const &a, ap_uint<total_bits> const &b, ap_uint<total_bits + 1> &result,
+                      bool carry_in) {
 #pragma HLS INLINE
-        const auto carry = _PipelinedAddImpl<total_bits, num_steps, step - 1>::Apply(a, b, result);
+        const auto carry_step = _PipelinedAddImpl<total_bits, num_steps, step - 1>::Apply(a, b, result, carry_in);
         const ap_uint<bits> a_chunk = a.range(bit_end - 1, bit_begin);
         const ap_uint<bits> b_chunk = b.range(bit_end - 1, bit_begin);
-        const ap_uint<bits + 1> add_result = PipelinedAdd(a_chunk, b_chunk);
-        const ap_uint<bits + 2> result_chunk = add_result + carry;
+        const ap_uint<bits + 2> result_chunk = PipelinedAdd(a_chunk, b_chunk, carry_step);
         result.range(bit_end - 1, bit_begin) = result_chunk.range(bits - 1, 0);
         return result_chunk.get_bit(bits);
     }
@@ -35,11 +35,12 @@ struct _PipelinedAddImpl<total_bits, num_steps, 1> {
     static constexpr int bit_end = total_bits / num_steps;
     static constexpr int bits = bit_end;
 
-    static bool Apply(ap_uint<total_bits> const &a, ap_uint<total_bits> const &b, ap_uint<total_bits + 1> &result) {
+    static bool Apply(ap_uint<total_bits> const &a, ap_uint<total_bits> const &b, ap_uint<total_bits + 1> &result,
+                      bool carry_in) {
 #pragma HLS INLINE
         const ap_uint<bits> a_chunk = a.range(bit_end - 1, 0);
         const ap_uint<bits> b_chunk = b.range(bit_end - 1, 0);
-        const ap_uint<bits + 1> result_chunk = PipelinedAdd(a_chunk, b_chunk);
+        const ap_uint<bits + 1> result_chunk = PipelinedAdd(a_chunk, b_chunk, carry_in);
         result.range(bit_end - 1, 0) = result_chunk.range(bits - 1, 0);
         return result_chunk.get_bit(bits);
     }
@@ -48,21 +49,31 @@ struct _PipelinedAddImpl<total_bits, num_steps, 1> {
 }  // namespace
 
 template <int bits>
-auto PipelinedAdd(ap_uint<bits> const &a, ap_uint<bits> const &b) ->
-    typename std::enable_if<(bits > kPipelinedAddBaseBits), ap_uint<bits + 1>>::type {
+auto PipelinedAdd(ap_uint<bits> const &a, ap_uint<bits> const &b, bool carry_in = false) ->
+    typename std::enable_if<(bits > kPipelinedAddBaseBits), ap_uint<bits + 2>>::type {
 #pragma HLS INLINE
     ap_uint<bits + 1> result;
     constexpr int num_steps = hlslib::CeilDivide(bits, kPipelinedAddBaseBits);
-    const auto carry = _PipelinedAddImpl<bits, num_steps, num_steps>::Apply(a, b, result);
-    result.set_bit(bits, carry);
+    const auto carry_out = _PipelinedAddImpl<bits, num_steps, num_steps>::Apply(a, b, result, carry_in);
+    result.set_bit(bits, carry_out);
     return result;
 }
 
 template <int bits>
-auto PipelinedAdd(ap_uint<bits> const &a, ap_uint<bits> const &b) ->
-    typename std::enable_if<(bits <= kPipelinedAddBaseBits), ap_uint<bits + 1>>::type {
+auto PipelinedAdd(ap_uint<bits> const &a, ap_uint<bits> const &b, bool carry_in = false) ->
+    typename std::enable_if<(bits <= kPipelinedAddBaseBits), ap_uint<bits + 2>>::type {
 #pragma HLS INLINE
-    const auto result = a + b;
+    const auto result = a + b + ap_uint<1>(carry_in ? 1 : 0);
 #pragma HLS BIND_OP variable = result op = add impl = fabric latency = AddLatency(bits)
+    return result;
+}
+
+template <int bits>
+auto PipelinedSub(ap_uint<bits> const &a, ap_uint<bits> const &b) -> ap_uint<bits + 1> {
+#pragma HLS INLINE
+    ap_uint<bits + 1> result;
+    constexpr int num_steps = hlslib::CeilDivide(bits, kPipelinedAddBaseBits);
+    const auto carry = _PipelinedAddImpl<bits, num_steps, num_steps>::Apply(a, ~b, result, true);
+    result.set_bit(bits, carry);
     return result;
 }


### PR DESCRIPTION
We use the `PipelinedAdd` implementation to create a pipelined sub using the identity `A - B = A + ~B + 1`. `PipelinedAdd` accepts a carry_in argument and is an extra bit wider on the output